### PR TITLE
Add option continueAndFail on step.onError

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -53,7 +53,8 @@ var (
 	breakpointOnFailure = flag.Bool("breakpoint_on_failure", false, "If specified, expect steps to not skip on failure")
 	debugBeforeStep     = flag.Bool("debug_before_step", false, "If specified, wait for a debugger to attach before executing the step")
 	onError             = flag.String("on_error", "", "Set to \"continue\" to ignore an error and continue when a container terminates with a non-zero exit code."+
-		" Set to \"stopAndFail\" to declare a failure with a step error and stop executing the rest of the steps.")
+		" Set to \"stopAndFail\" to declare a failure with a step error and stop executing the rest of the steps."+
+		" Set to \"continueAndFail\" to declare a failure with a step error after having executed the rest of the steps.")
 	stepMetadataDir        = flag.String("step_metadata_dir", "", "If specified, create directory to store the step metadata e.g. /tekton/steps/<step-name>/")
 	resultExtractionMethod = flag.String("result_from", entrypoint.ResultExtractionMethodTerminationMessage, "The method using which to extract results from tasks. Default is using the termination message.")
 )

--- a/config/300-crds/300-task.yaml
+++ b/config/300-crds/300-task.yaml
@@ -6808,7 +6808,7 @@ spec:
                       onError:
                         description: |-
                           OnError defines the exiting behavior of a container on error
-                          can be set to [ continue | stopAndFail ]
+                          can be set to [ continue | stopAndFail | continueAndFail ]
                         type: string
                       params:
                         description: Params declares parameters passed to this step action.

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -6439,7 +6439,7 @@ spec:
                           onError:
                             description: |-
                               OnError defines the exiting behavior of a container on error
-                              can be set to [ continue | stopAndFail ]
+                              can be set to [ continue | stopAndFail | continueAndFail ]
                             type: string
                           params:
                             description: Params declares parameters passed to this step action.

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1755,6 +1755,9 @@ IncludeParamsList
 <tbody><tr><td><p>&#34;continue&#34;</p></td>
 <td><p>Continue indicates continue executing the rest of the steps irrespective of the container exit code</p>
 </td>
+</tr><tr><td><p>&#34;continueAndFail&#34;</p></td>
+<td><p>ContinueAndFail indicates continue executing the rest of the steps irrespective of the container exit code and exit after all steps are completed with the first possible non-zero exit code of the step that has this OnErrorType</p>
+</td>
 </tr><tr><td><p>&#34;stopAndFail&#34;</p></td>
 <td><p>StopAndFail indicates exit the taskRun if the container exits with non-zero exit code</p>
 </td>
@@ -4609,7 +4612,7 @@ OnErrorType
 </td>
 <td>
 <p>OnError defines the exiting behavior of a container on error
-can be set to [ continue | stopAndFail ]</p>
+can be set to [ continue | stopAndFail | continueAndFail ]</p>
 </td>
 </tr>
 <tr>

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -330,10 +330,14 @@ When a `step` in a `task` results in a failure, the rest of the steps in the `ta
 declared a failure. If you would like to ignore such step errors and continue executing the rest of the steps in
 the task, you can specify `onError` for such a `step`.
 
-`onError` can be set to either `continue` or `stopAndFail` as part of the step definition. If `onError` is
+`onError` can be set to `continue`, `stopAndFail` or `continueAndFail` as part of the step definition. If `onError` is
 set to `continue`, the entrypoint sets the original failed exit code of the [script](#running-scripts-within-steps)
 in the container terminated state. A `step` with `onError` set to `continue` does not fail the `taskRun` and continues
 executing the rest of the steps in a task.
+
+If `onError` is set to `continueAndFail`, the `taskRun` continues executing the rest of the steps in a task and if no
+following `step` fails, the `taskRun` fails eventually with the exit code of the step that had set `onError` with
+`continueAndFail`.
 
 To ignore a step error, set `onError` to `continue`:
 

--- a/pkg/apis/pipeline/v1/container_types.go
+++ b/pkg/apis/pipeline/v1/container_types.go
@@ -127,7 +127,7 @@ type Step struct {
 	Workspaces []WorkspaceUsage `json:"workspaces,omitempty"`
 
 	// OnError defines the exiting behavior of a container on error
-	// can be set to [ continue | stopAndFail ]
+	// can be set to [ continue | stopAndFail | continueAndFail ]
 	OnError OnErrorType `json:"onError,omitempty"`
 	// Stores configuration for the stdout stream of the step.
 	// +optional
@@ -173,6 +173,8 @@ const (
 	StopAndFail OnErrorType = "stopAndFail"
 	// Continue indicates continue executing the rest of the steps irrespective of the container exit code
 	Continue OnErrorType = "continue"
+	// Continue indicates continue executing the rest of the steps irrespective of the container exit code and exit after all steps are completed with the first possible non-zero exit code of the step that has this OnErrorType
+	ContinueAndFail OnErrorType = "continueAndFail"
 )
 
 // StepOutputConfig stores configuration for a step output stream.

--- a/pkg/apis/pipeline/v1/container_validation.go
+++ b/pkg/apis/pipeline/v1/container_validation.go
@@ -207,11 +207,11 @@ func (s *Step) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	if s.OnError != "" {
-		if !isParamRefs(string(s.OnError)) && s.OnError != Continue && s.OnError != StopAndFail {
+		if !isParamRefs(string(s.OnError)) && s.OnError != Continue && s.OnError != StopAndFail && s.OnError != ContinueAndFail {
 			errs = errs.Also(&apis.FieldError{
 				Message: fmt.Sprintf("invalid value: \"%v\"", s.OnError),
 				Paths:   []string{"onError"},
-				Details: "Task step onError must be either \"continue\" or \"stopAndFail\"",
+				Details: "Task step onError must be \"continue\", \"stopAndFail\" or \"continueAndFail\"",
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -669,7 +669,7 @@ func TestStepOnError(t *testing.T) {
 		},
 	}, {
 		name: "valid step - valid onError usage - set to continueAndFail",
-		steps: []v1.Step{{
+		step: []v1.Step{{
 			OnError: v1.ContinueAndFail,
 			Image:   "image",
 			Args:    []string{"arg"},

--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -669,11 +669,11 @@ func TestStepOnError(t *testing.T) {
 		},
 	}, {
 		name: "valid step - valid onError usage - set to continueAndFail",
-		step: []v1.Step{{
+		step: v1.Step{
 			OnError: v1.ContinueAndFail,
 			Image:   "image",
 			Args:    []string{"arg"},
-		}},
+		},
 	}, {
 		name: "valid step - valid onError usage - set to a task parameter",
 		params: []v1.ParamSpec{{

--- a/pkg/apis/pipeline/v1/container_validation_test.go
+++ b/pkg/apis/pipeline/v1/container_validation_test.go
@@ -668,6 +668,13 @@ func TestStepOnError(t *testing.T) {
 			Args:    []string{"arg"},
 		},
 	}, {
+		name: "valid step - valid onError usage - set to continueAndFail",
+		steps: []v1.Step{{
+			OnError: v1.ContinueAndFail,
+			Image:   "image",
+			Args:    []string{"arg"},
+		}},
+	}, {
 		name: "valid step - valid onError usage - set to a task parameter",
 		params: []v1.ParamSpec{{
 			Name:    "CONTINUE",
@@ -688,7 +695,7 @@ func TestStepOnError(t *testing.T) {
 		expectedError: &apis.FieldError{
 			Message: `invalid value: "onError"`,
 			Paths:   []string{"onError"},
-			Details: `Task step onError must be either "continue" or "stopAndFail"`,
+			Details: `Task step onError must be "continue", "stopAndFail" or "continueAndFail"`,
 		},
 	}}
 	for _, st := range tests {

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -3051,7 +3051,7 @@ func schema_pkg_apis_pipeline_v1_Step(ref common.ReferenceCallback) common.OpenA
 					},
 					"onError": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OnError defines the exiting behavior of a container on error can be set to [ continue | stopAndFail ]",
+							Description: "OnError defines the exiting behavior of a container on error can be set to [ continue | stopAndFail | continueAndFail ]",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1523,7 +1523,7 @@
           "default": ""
         },
         "onError": {
-          "description": "OnError defines the exiting behavior of a container on error can be set to [ continue | stopAndFail ]",
+          "description": "OnError defines the exiting behavior of a container on error can be set to [ continue | stopAndFail | continueAndFail ]",
           "type": "string"
         },
         "params": {

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -154,9 +154,9 @@ func orderContainers(ctx context.Context, commonExtraEntrypointArgs []string, st
 		if taskSpec != nil {
 			if taskSpec.Steps != nil && len(taskSpec.Steps) >= i+1 {
 				if taskSpec.Steps[i].OnError != "" {
-					if taskSpec.Steps[i].OnError != v1.Continue && taskSpec.Steps[i].OnError != v1.StopAndFail {
-						return nil, fmt.Errorf("task step onError must be either \"%s\" or \"%s\" but it is set to an invalid value \"%s\"",
-							v1.Continue, v1.StopAndFail, taskSpec.Steps[i].OnError)
+					if taskSpec.Steps[i].OnError != v1.Continue && taskSpec.Steps[i].OnError != v1.StopAndFail && taskSpec.Steps[i].OnError != v1.ContinueAndFail {
+						return nil, fmt.Errorf("task step onError must have one of the following values: \"%s\", \"%s\" or \"%s\". But it is set to an invalid value \"%s\"",
+							v1.Continue, v1.StopAndFail, v1.ContinueAndFail, taskSpec.Steps[i].OnError)
 					}
 					argsForEntrypoint = append(argsForEntrypoint, "-on_error", string(taskSpec.Steps[i].OnError))
 				}

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -22,8 +22,9 @@ package test
 import (
 	"context"
 	"fmt"
-	"testing"
 	"strings"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -35,7 +36,7 @@ import (
 )
 
 var (
-	onErrorContinue = "continue"
+	onErrorContinue        = "continue"
 	onErrorContinueAndFail = "continueAndFail"
 )
 
@@ -46,8 +47,8 @@ func successfulStep(name string, onError *string) string {
         script: 'echo hello'`, name)
 
 	if onError != nil {
-		step += "\n" + fmt.Sprintf(`
-        onError: %s`, *onError)
+		step += "\n" + `
+        onError: ` + *onError
 	}
 
 	return step
@@ -60,8 +61,8 @@ func failingStep(name string, onError *string) string {
         script: 'echo -n 123 | tee $(results.result1.path); exit 1; echo -n 456 | tee $(results.result2.path)'`, name)
 
 	if onError != nil {
-		step += "\n" + fmt.Sprintf(`
-        onError: %s`, *onError)
+		step += "\n" + `
+        onError: ` + *onError
 	}
 
 	return step
@@ -76,100 +77,100 @@ func TestFailingStepOnContinue(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	tests := []struct {
-		description   string
-		steps 	      []string
-		shouldSucceed bool
+		description       string
+		steps             []string
+		shouldSucceed     bool
 		expectedStatusMsg string
-		state         string
-		conditionFn   func(name string) ConditionAccessorFn
+		state             string
+		conditionFn       func(name string) ConditionAccessorFn
 	}{
 		{
-			description:   "failing step with onError continue and successful follow-up step",
+			description: "failing step with onError continue and successful follow-up step",
 			steps: []string{
 				failingStep("failing-step", &onErrorContinue),
 				successfulStep("successful-step", nil),
 			},
-			shouldSucceed: true,
+			shouldSucceed:     true,
 			expectedStatusMsg: "All Steps have completed executing",
-			state:         "TaskRunSucceeded",
-			conditionFn:   TaskRunSucceed,
+			state:             "TaskRunSucceeded",
+			conditionFn:       TaskRunSucceed,
 		},
 		{
-			description:   "failing step with onError continueAndFail and successful follow-up step",
+			description: "failing step with onError continueAndFail and successful follow-up step",
 			steps: []string{
 				failingStep("failing-step", &onErrorContinueAndFail),
 				successfulStep("successful-step", nil),
 			},
-			shouldSucceed: false,
+			shouldSucceed:     false,
 			expectedStatusMsg: `"step-failing-step" exited with code 1`,
-			state:         "TaskRunFailed",
-			conditionFn:   TaskRunFailed,
+			state:             "TaskRunFailed",
+			conditionFn:       TaskRunFailed,
 		},
 		{
-			description:   "failing step with onError continue and failing follow-up step",
+			description: "failing step with onError continue and failing follow-up step",
 			steps: []string{
 				failingStep("failing-step-1", &onErrorContinue),
 				failingStep("failing-step-2", nil),
 			},
-			shouldSucceed: false,
+			shouldSucceed:     false,
 			expectedStatusMsg: `"step-failing-step-2" exited with code 1`,
-			state:         "TaskRunFailed",
-			conditionFn:   TaskRunFailed,
+			state:             "TaskRunFailed",
+			conditionFn:       TaskRunFailed,
 		},
 		{
-			description:   "failing step with onError continueAndFail and failing follow-up step",
+			description: "failing step with onError continueAndFail and failing follow-up step",
 			steps: []string{
 				failingStep("failing-step-1", &onErrorContinueAndFail),
 				failingStep("failing-step-2", nil),
 			},
-			shouldSucceed: false,
+			shouldSucceed:     false,
 			expectedStatusMsg: `"step-failing-step-1" exited with code 1`,
-			state:         "TaskRunFailed",
-			conditionFn:   TaskRunFailed,
+			state:             "TaskRunFailed",
+			conditionFn:       TaskRunFailed,
 		},
 		{
-			description:   "failing step with onError continue and failing follow-up step with onError continueAndFail",
+			description: "failing step with onError continue and failing follow-up step with onError continueAndFail",
 			steps: []string{
 				failingStep("failing-step-1", &onErrorContinue),
 				failingStep("failing-step-2", &onErrorContinueAndFail),
 			},
-			shouldSucceed: false,
+			shouldSucceed:     false,
 			expectedStatusMsg: `"step-failing-step-2" exited with code 1`,
-			state:         "TaskRunFailed",
-			conditionFn:   TaskRunFailed,
+			state:             "TaskRunFailed",
+			conditionFn:       TaskRunFailed,
 		},
 		{
-			description:   "failing step with onError continueAndFail and failing follow-up step with onError continueAndFail",
+			description: "failing step with onError continueAndFail and failing follow-up step with onError continueAndFail",
 			steps: []string{
 				failingStep("failing-step-1", &onErrorContinueAndFail),
 				failingStep("failing-step-2", &onErrorContinueAndFail),
 			},
-			shouldSucceed: false,
+			shouldSucceed:     false,
 			expectedStatusMsg: `"step-failing-step-1" exited with code 1`,
-			state:         "TaskRunFailed",
-			conditionFn:   TaskRunFailed,
+			state:             "TaskRunFailed",
+			conditionFn:       TaskRunFailed,
 		},
 		{
-			description:   "failing step with onError continue and failing follow-up step with onError continue",
+			description: "failing step with onError continue and failing follow-up step with onError continue",
 			steps: []string{
 				failingStep("failing-step-1", &onErrorContinue),
 				failingStep("failing-step-2", &onErrorContinue),
 			},
-			shouldSucceed: true,
+			shouldSucceed:     true,
 			expectedStatusMsg: "All Steps have completed executing",
-			state:         "TaskRunSucceeded",
-			conditionFn:   TaskRunSucceed,
+			state:             "TaskRunSucceeded",
+			conditionFn:       TaskRunSucceed,
 		},
 		{
-			description:   "failing step with onError continueAndFail and failing follow-up step with onError continue",
+			description: "failing step with onError continueAndFail and failing follow-up step with onError continue",
 			steps: []string{
 				failingStep("failing-step-1", &onErrorContinueAndFail),
 				failingStep("failing-step-2", &onErrorContinue),
 			},
-			shouldSucceed: false,
+			shouldSucceed:     false,
 			expectedStatusMsg: `"step-failing-step-1" exited with code 1`,
-			state:         "TaskRunFailed",
-			conditionFn:   TaskRunFailed,
+			state:             "TaskRunFailed",
+			conditionFn:       TaskRunFailed,
 		},
 	}
 

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestFailingStepOnContinue(t *testing.T) {
@@ -40,8 +41,35 @@ func TestFailingStepOnContinue(t *testing.T) {
 	c, namespace := setup(ctx, t)
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
-	taskRunName := "mytaskrun"
-	tr := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+
+	tests := []struct {
+		description   string
+		onError       string
+		shouldSucceed bool
+		state         string
+		conditionFn   func(name string) ConditionAccessorFn
+	}{
+		{
+			description:   "continue and succeed",
+			onError:       "continue",
+			shouldSucceed: true,
+			state:         "TaskRunSucceeded",
+			conditionFn:   TaskRunSucceed,
+		},
+		{
+			description:   "continue and fail",
+			onError:       "continueAndFail",
+			shouldSucceed: false,
+			state:         "TaskRunFailed",
+			conditionFn:   TaskRunFailed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			taskRunName := helpers.ObjectNameForTest(t)
+
+			tr := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
   namespace: %s
@@ -52,36 +80,41 @@ spec:
       - name: result2
     steps:
       - name: failing-step
-        onError: continue
+        onError: %s
         image: mirror.gcr.io/busybox
         script: 'echo -n 123 | tee $(results.result1.path); exit 1; echo -n 456 | tee $(results.result2.path)'
-`, taskRunName, namespace))
+      - name: successful-step
+        image: mirror.gcr.io/busybox
+        script: 'echo hello'
+`, taskRunName, namespace, test.onError))
 
-	if _, err := c.V1TaskRunClient.Create(ctx, tr, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun: %s", err)
-	}
+			if _, err := c.V1TaskRunClient.Create(ctx, tr, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create TaskRun: %s", err)
+			}
 
-	t.Logf("Waiting for TaskRun in namespace %s to finish", namespace)
-	if err := WaitForTaskRunState(ctx, c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceeded", v1Version); err != nil {
-		t.Errorf("Error waiting for TaskRun to finish: %s", err)
-	}
+			t.Logf("Waiting for TaskRun in namespace %s to finish", namespace)
+			if err := WaitForTaskRunState(ctx, c, taskRunName, test.conditionFn(taskRunName), test.state, v1Version); err != nil {
+				t.Errorf("Error waiting for TaskRun to finish: %s", err)
+			}
 
-	taskRun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
-	}
+			taskRun, err := c.V1TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+			}
 
-	if !taskRun.Status.GetCondition(apis.ConditionSucceeded).IsTrue() {
-		t.Fatalf("Expected TaskRun %s to have succeeded but Status is %v", taskRunName, taskRun.Status)
-	}
+			if taskRun.Status.GetCondition(apis.ConditionSucceeded).IsTrue() != test.shouldSucceed {
+				t.Fatalf("Expected TaskRun %s ConditionSucceeded to be %t, but Status is %v", taskRunName, test.shouldSucceed, taskRun.Status)
+			}
 
-	expectedResults := []v1.TaskRunResult{{
-		Name:  "result1",
-		Type:  "string",
-		Value: *v1.NewStructuredValues("123"),
-	}}
+			expectedResults := []v1.TaskRunResult{{
+				Name:  "result1",
+				Type:  "string",
+				Value: *v1.NewStructuredValues("123"),
+			}}
 
-	if d := cmp.Diff(expectedResults, taskRun.Status.Results); d != "" {
-		t.Errorf("Got unexpected results %s", diff.PrintWantGot(d))
+			if d := cmp.Diff(expectedResults, taskRun.Status.Results); d != "" {
+				t.Errorf("Got unexpected results %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -283,7 +283,7 @@ spec:
 			},
 		},
 		{
-			description:   "termination continued",
+			description:   "termination continued (continue)",
 			shouldSucceed: true,
 			taskRun: `
 metadata:
@@ -305,6 +305,50 @@ spec:
 					ContainerState: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 1,
+							Reason:   "Completed",
+						},
+					},
+				},
+			},
+		},
+		{
+			description:   "termination continued (continueAndFail)",
+			shouldSucceed: false,
+			taskRun: `
+metadata:
+  name: %v
+  namespace: %v
+spec:
+  taskSpec:
+    steps:
+    - image: %v
+      onError: continueAndFail
+      name: first
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello; exit 1']
+    - image: %v
+      name: second
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello']`,
+			expectedStepStatus: []v1.StepState{
+				{
+					Container:         "step-first",
+					Name:              "first",
+					TerminationReason: "Continued",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Reason:   "Error",
+						},
+					},
+				},
+				{
+					Container:         "step-second",
+					Name:              "second",
+					TerminationReason: "Completed",
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
 							Reason:   "Completed",
 						},
 					},


### PR DESCRIPTION
## Feature request

Currently `onError` for steps can be set to `continue` or `stopAndFail`. In some cases, it could be beneficial to allow the `taskRun` to continue with the rest of the steps, but eventually fail with the exitCode of a specific step. Therefore, I'm introducing the value `continueAndFail`.

This is already discussed in the [comments](https://github.com/tektoncd/pipeline/issues/4485#issuecomment-1013535629) of issue #4485

## Use case

I have a task that runs a test (step 1) and publishes a test report (step 2). I want to publish a test report even if step 1 fails and let the taskRun fail accordingly (step 2 exitCode).
In that case, none of the current values of onError are enough, as `continue` would make the taskRun succeed and `stopAndFail` would prevent step 2 from running.
